### PR TITLE
Support to run F1 on Linux systems (on x86_64 architecture)

### DIFF
--- a/F1/__main__.py
+++ b/F1/__main__.py
@@ -1,6 +1,7 @@
 import F1
 import sys
 import json
+import os
 def main():
     if len(sys.argv) < 2:
         print('''
@@ -17,16 +18,19 @@ Usage: python -m F1 <grammar.json>
     with open('vm_ops.s', 'w+') as f:
         print(vm_ops, file=f)
 
-    with open('fuzz.s', 'w+') as f:
+    with open('fuzz.S', 'w+') as f:
         print(fuzz_src, file=f)
 
     with open('main.c', 'w+') as f:
         print(main_src, file=f)
 
-    print('''\
-Next step:
-$ cc -g -Ofast -o fuzzer main.c fuzz.s
-$ rm -f io.x
+    uname = os.uname()
+    print('\nNext step:')
+    if uname.sysname == "Darwin":
+        print('$ cc -g -Ofast -o fuzzer main.c fuzz.S')
+    elif uname.sysname == "Linux":
+        print('$ clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S')
+    print('''$ rm -f io.x
 $ ./fuzzer 0 1000 1000
 $ cat io.x
 ''')

--- a/F1/fuzzer.py
+++ b/F1/fuzzer.py
@@ -1,6 +1,7 @@
 import itertools
 import sys
 import random
+import os
 
 class Sanitize:
     def __init__(self, g):
@@ -536,6 +537,7 @@ void gen_init__() {
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
+#include <stdint.h>
 '''
 
     def gen_main_src(self):
@@ -1120,11 +1122,18 @@ _%(key)s_%(ruleid)s_fi:
         return '\n'.join(result)
  
     def fn_fuzz_decs(self):
-        result = ['''
-  .section  __DATA,__data
+        if os.uname().sysname == "Darwin":
+            result = ['''
+.section  __DATA,__data
+''']
 
+        elif os.uname().sysname == "Linux":
+            result = ['''
+.section  __DATA
+''']
+        result.append('''\
 # Virtual Machine OPS.
-        ''']
+''')
         for k in self.grammar:
             result.append('''
     .globl  _%(key)s_choices

--- a/F1/fuzzer.py
+++ b/F1/fuzzer.py
@@ -69,6 +69,7 @@ class CTrans(Sanitize):
 class Fuzzer:
     def __init__(self, grammar):
         self.grammar = grammar
+        self.system_name = os.uname().sysname # expect "Darwin" and "Linux"
     
     def fuzz(self, key='<start>', max_num=None, max_depth=None):
         raise NotImplemented()
@@ -752,8 +753,11 @@ int main(int argc, char** argv) {
 
 class CFWriteFuzzer(CFuzzerExtRandP):
     def main_out_var_defs(self):
-        return '''
-const uint64_t size = UINT_MAX; /*max size of a single input -- 4G*/
+        if self.system_name == "Darwin":
+            ret_str = 'const uint64_t size = UINT_MAX; /*max size of a single input -- 4G*/'
+        elif self.system_name == "Linux":
+            ret_str = 'const uint64_t size = UINT_MAX/100; /*max size of a single input -- 40M*/' 
+        return ret_str + '''
 char out_region_initp[size];
 char *out_regionp = out_region_initp;
 uint64_t out_cursor = 0;
@@ -971,11 +975,15 @@ return_abort:
 
     
     def main_stack_var_defs(self):
+        if self.system_name == "Darwin":
+            ret_str = 'void* stackp[INT_MAX];\n'
+        elif self.system_name == "Linux":
+            ret_str = 'void* stackp[INT_MAX/100];\n'
         return'''
 int max_depth;
 void** max_depthp;
-void* stackp[INT_MAX];
-'''
+''' + ret_str
+
     def main_init_var_defs(self):
         return'''
 void gen_init__(void** max_depthp);
@@ -1122,12 +1130,12 @@ _%(key)s_%(ruleid)s_fi:
         return '\n'.join(result)
  
     def fn_fuzz_decs(self):
-        if os.uname().sysname == "Darwin":
+        if self.system_name == "Darwin":
             result = ['''
 .section  __DATA,__data
 ''']
 
-        elif os.uname().sysname == "Linux":
+        elif self.system_name == "Linux":
             result = ['''
 .section  __DATA
 ''']

--- a/F1/fuzzer.py
+++ b/F1/fuzzer.py
@@ -1137,7 +1137,7 @@ _%(key)s_%(ruleid)s_fi:
 
         elif self.system_name == "Linux":
             result = ['''
-.section  __DATA
+.text
 ''']
         result.append('''\
 # Virtual Machine OPS.
@@ -1172,9 +1172,13 @@ _%(key)s_prints:''' % {'key':self.k_to_s(k)})
         all_strings = list(all_strings)
         all_strings.sort(key=lambda item: (-len(item), item))
         all_prints_hash = {}
-        result = ['''
+        if self.system_name == "Darwin":
+            result = ['''
 .text
-        ''']
+            ''']
+        elif self.system_name == "Linux":
+            result = ['''
+            ''']
         for i, s_ in enumerate(all_strings):
             s = s_
             result.append('''\

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # F1 Fuzzer
 
-This is the F1 Fuzzer described in the paper [Building Fast
-Fuzzers](https://arxiv.org/abs/1911.07707).
+This is the F1 Fuzzer described in the paper [Building Fast Fuzzers](https://arxiv.org/abs/1911.07707).
 
 If you use F1 in a production setting, if you found bugs with it (yay!), or if
 you have any suggestions to share, please let us know – your experience is very
@@ -10,8 +9,8 @@ valuable for us.  Thanks!
 
 ### List of changes made to the sourcecode to make it run on Linux systems - ###
 - "stdint.h" header included in main.c
-- ".section  \_\_DATA" in place of ".section  \_\_DATA,\_\_data"
 - fuzz\_src is written to fuzz.S instead of fuzz.s
 - "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S" in place of "cc -g -Ofast -o fuzzer main.c fuzz.S" in MacOS
 - stackp's array size is INT\_MAX/100 in Linux (INT\_MAX in MacOS)
 - out\_region\_initp's arraysize is UINT\_MAX/100 (UINT\_MAX in MacOS)
+- all contents of ".section  __DATA,__data" is moved to ".text" section in vm\_ops.s

--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ Fuzzers](https://arxiv.org/abs/1911.07707).
 If you use F1 in a production setting, if you found bugs with it (yay!), or if
 you have any suggestions to share, please let us know – your experience is very
 valuable for us.  Thanks!
+
+
+### List of changes made to the sourcecode to make it run on Linux systems - ###
+- "stdint.h" header included in main.c
+- ".section  \_\_DATA" in place of ".section  \_\_DATA,\_\_data"
+- fuzz\_src is written to fuzz.S instead of fuzz.s
+- "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S" in place of "cc -g -Ofast -o fuzzer main.c fuzz.S" in MacOS
+- stackp's array size is INT\_MAX/100 in Linux (INT\_MAX in MacOS)
+- out\_region\_initp's arraysize is UINT\_MAX/100 (UINT\_MAX in MacOS)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ valuable for us.  Thanks!
 
 
 ### List of changes made to the sourcecode to make it run on Linux systems - ###
+- Requires clang to work in Linux 
 - "stdint.h" header included in main.c
 - fuzz\_src is written to fuzz.S instead of fuzz.s
-- "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S" in place of "cc -g -Ofast -o fuzzer main.c fuzz.S" in MacOS
+- Compiled in Linux using "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S"
+  while MacOS compiles using "cc -g -Ofast -o fuzzer main.c fuzz.S"
 - stackp's array size is INT\_MAX/100 in Linux (INT\_MAX in MacOS)
 - out\_region\_initp's arraysize is UINT\_MAX/100 (UINT\_MAX in MacOS)
 - all contents of ".section  __DATA,__data" is moved to ".text" section in vm\_ops.s


### PR DESCRIPTION
F1 can now also be run on Linux systems (in x86_64 architecture) using the following changes. This has been tested on the rahul7 machine. 

The README lists the list of changes made. Also adding here for convenience:
### List of changes made to the sourcecode to make it run on Linux systems - ###
- Requires clang to work in Linux
- "stdint.h" header included in main.c
- fuzz_src is written to fuzz.S instead of fuzz.s
- Compiled in Linux using "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S"
  while MacOS compiles using "cc -g -Ofast -o fuzzer main.c fuzz.S"
- stackp's array size is INT_MAX/100 in Linux (INT_MAX in MacOS)
- out_region_initp's arraysize is UINT_MAX/100 (UINT_MAX in MacOS)
- all contents of ".section  __DATA,__data" is moved to ".text" section in vm_ops.s